### PR TITLE
Fix font file not copied into the dist folder

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,18 @@
 		"http://fontfabric.com/"
 	],
 	"description": "Kelson Sans is remake of the original Kelson type family – designed by Bruno Mello.",
-	"main": "stylesheet.css",
+	"main": [
+	      "stylesheet.css",
+	      "font/kelson_sans_bold_ru.woff",
+	      "font/kelson_sans_bold_ru.eot",
+	      "font/kelson_sans_bold_ru.ttf",
+	      "font/kelson_sans_regular_ru.woff",
+	      "font/kelson_sans_regular_ru.eot",
+	      "font/kelson_sans_regular_ru.ttf",
+	      "font/kelson_sans_light_ru.woff",
+	      "font/kelson_sans_light_ru.eot",
+	      "font/kelson_sans_light_ru.ttf"
+	    ],
 	"keywords": [
 		"font",
 		"kelson sans",


### PR DESCRIPTION
Font file were not copied into the dist folder when running `gulp build`
